### PR TITLE
bump kubernetes to 1.18.6

### DIFF
--- a/.final_builds/packages/kubernetes-windows/index.yml
+++ b/.final_builds/packages/kubernetes-windows/index.yml
@@ -11,6 +11,10 @@ builds:
     version: 4abcc3b37113dd56b098fa1ee73212f93cac093f7de203983b90de5f90b52a3a
     blobstore_id: 7be5f22a-abea-4a48-43f2-6c15789e898e
     sha1: sha256:b7922bc86de6ce28ed7eda7246767c05f58345d9ff646ee6ae3b2276ec02b676
+  7ea9526bfb7d43ffdc7e171c113c6402193f2ea2aa554b7fee6bf0fc83f01532:
+    version: 7ea9526bfb7d43ffdc7e171c113c6402193f2ea2aa554b7fee6bf0fc83f01532
+    blobstore_id: 2f4e13b8-f6fc-4f42-515a-f1459240542c
+    sha1: sha256:56612e4f3bc142110fdbefdb14289a0489647ab1aa49c5ebd17e205ff31935b1
   bbee50d7c5c05b58f4debfcd8c327c7a8ad25b01:
     version: bbee50d7c5c05b58f4debfcd8c327c7a8ad25b01
     blobstore_id: 4e8017e2-be83-455a-6da4-8f8ccabceec5

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,15 +10,15 @@ flannel-v0.11.0-44-g3f87efc4-windows-amd64.tar.gz:
   size: 9548976
   object_id: 1a947dbf-c668-4e34-63c8-63d1aaa715d4
   sha: 7c68f433e4aac88210110df1d0596ee6b46f6157
-kubernetes-windows-1.17.3/kube-proxy.exe:
-  size: 41721856
-  object_id: 1930cb1d-4271-4e8c-5a4f-74942d5748c6
-  sha: 7fa75aeb7839cdb37ca5501ece0bc6d82329f1dc
-kubernetes-windows-1.17.3/kubectl.exe:
-  size: 43988992
-  object_id: 60e88c78-9868-4ab9-43ec-46756b5c7f03
-  sha: 56263d22814a4c6d1cbcc6bb6a6af85848880952
-kubernetes-windows-1.17.3/kubelet.exe:
-  size: 107438592
-  object_id: b8620731-c554-4374-4e29-8520c6ebe541
-  sha: 7cb35ffd25ed03211407c5cbb38ad962669df6c7
+kubernetes-windows-1.18.6/kube-proxy.exe:
+  size: 42633728
+  object_id: e2090f1e-7efb-4ca3-6ede-5a5412e59477
+  sha: 51f6ca7deec7c8b38338ee319ede14a1a2ed5f3d
+kubernetes-windows-1.18.6/kubectl.exe:
+  size: 44527104
+  object_id: de2e2684-46dd-4a3f-4d7a-c5251c5355be
+  sha: 429a15340dffb9587238811c856ed5bc0fc0f8c5
+kubernetes-windows-1.18.6/kubelet.exe:
+  size: 109067776
+  object_id: 77e0aab6-cfd8-4b00-7577-c1049fe818ac
+  sha: 36f10ef9c11b2858b11adfce42f9506a0e9bd9f3

--- a/packages/kubernetes-windows/packaging
+++ b/packages/kubernetes-windows/packaging
@@ -3,7 +3,7 @@
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
-$KUBERNETES_VERSION="1.17.3"
+$KUBERNETES_VERSION="1.18.6"
 
 New-Item -Path "${env:BOSH_INSTALL_TARGET}" -Name "bin" -ItemType "directory"
 

--- a/packages/kubernetes-windows/spec
+++ b/packages/kubernetes-windows/spec
@@ -2,5 +2,5 @@
 name: kubernetes-windows
 
 files:
-- kubernetes-windows-1.17.3/*
+- kubernetes-windows-1.18.6/*
 - exiter.ps1

--- a/releases/kubo-windows/index.yml
+++ b/releases/kubo-windows/index.yml
@@ -19,6 +19,8 @@ builds:
     version: 1.9.0-build.6
   d6eeb156-5ebb-4951-5631-39c269d598e3:
     version: 0.40.0
+  e1236d6a-06e6-45d1-52d0-9f63f1e50466:
+    version: 1.9.0-build.24-bump-kubernetes-1.18.6
   f52d4994-1835-4c3a-55e9-a3df6d24bb4c:
     version: 0.39.0
 format-version: "2"

--- a/releases/kubo-windows/kubo-windows-1.9.0-build.24-bump-kubernetes-1.18.6.yml
+++ b/releases/kubo-windows/kubo-windows-1.9.0-build.24-bump-kubernetes-1.18.6.yml
@@ -1,0 +1,54 @@
+name: kubo-windows
+version: 1.9.0-build.24-bump-kubernetes-1.18.6
+commit_hash: 8af8579
+uncommitted_changes: false
+jobs:
+- name: docker-windows
+  version: c1e2dc1c463965f28c89723ed4d43eadc7486e8ee6e74387f6a7e414268cd2c8
+  fingerprint: c1e2dc1c463965f28c89723ed4d43eadc7486e8ee6e74387f6a7e414268cd2c8
+  sha1: sha256:b22af01adcfd0f95ac10355081a42aaf815d2852d34ec5ce2ec8d5acf14484db
+- name: flanneld-windows
+  version: f0db5782473d9bf829c78710cf63b98cc4139205c7a3bb17bb31c1f396a9edcf
+  fingerprint: f0db5782473d9bf829c78710cf63b98cc4139205c7a3bb17bb31c1f396a9edcf
+  sha1: sha256:f5e99a2f3d914b85e8c6bb8e7fc182fe5bebf05ef6c19c5eb9f9d8bffcfe6b14
+- name: kube-proxy-windows
+  version: 0a927db186e716fef89dfbff53d17e91298d554a38d6c0979dabb941e04af1d7
+  fingerprint: 0a927db186e716fef89dfbff53d17e91298d554a38d6c0979dabb941e04af1d7
+  sha1: sha256:87aa043744ac51273e2625d8896179d5a82dd958855c8259cbc2cf0f25e2ad43
+- name: kubelet-windows
+  version: 31caa788037fa81a6d24b51d0c5d9b4eb63e747bb18d85fa95282c2311328523
+  fingerprint: 31caa788037fa81a6d24b51d0c5d9b4eb63e747bb18d85fa95282c2311328523
+  sha1: sha256:d70a8daaafc50598a72e4e977e87312028c93506317885b16173535d88d563cd
+- name: kubo-dns-aliases
+  version: 0b18a6e6006651877e1df15d8c8f3b2e1e5a8ebf33f24622d5bad47bf2d91979
+  fingerprint: 0b18a6e6006651877e1df15d8c8f3b2e1e5a8ebf33f24622d5bad47bf2d91979
+  sha1: sha256:0c64a16f97a1800f5a3ccf200b04a294302cc8b357ba5bed0f52902d089bb55b
+- name: print-kubo-windows-component-version
+  version: 3325ca1e1817e02d7d61ac581e1a6e99b78bbbccb1fd43634d7b4a208be6bcf6
+  fingerprint: 3325ca1e1817e02d7d61ac581e1a6e99b78bbbccb1fd43634d7b4a208be6bcf6
+  sha1: sha256:4cefcc66623c51ae66e5db7ba262d221ba245c3346c50363613787b80d3abfee
+packages:
+- name: cni-windows
+  version: 424ee252a52e8f6a6defb753ef4e8d3b6d6b8fdc99aac97168924b248820240d
+  fingerprint: 424ee252a52e8f6a6defb753ef4e8d3b6d6b8fdc99aac97168924b248820240d
+  sha1: sha256:be5be144ba6993c1768f763788039c887abb5f820bc288a7bd08c2dc6f840dac
+  dependencies: []
+- name: docker-windows
+  version: 59efc37e25fcf9d61c3433e9b819759266199a001840f98940962f3fd878b910
+  fingerprint: 59efc37e25fcf9d61c3433e9b819759266199a001840f98940962f3fd878b910
+  sha1: sha256:f0307116da83f5d7e99402d6a000f2a7505e38d132ce36ddc36bedb41bfc2a47
+  dependencies: []
+- name: flanneld-windows
+  version: 23e6f8d7c0c175e035d6ac99e2f182957b8911666335d9e3f04c007152bd456d
+  fingerprint: 23e6f8d7c0c175e035d6ac99e2f182957b8911666335d9e3f04c007152bd456d
+  sha1: sha256:a160a9252db741b5aaa23b787084851dcc6c2fc8ff5a468a715ae4634d0d1c9b
+  dependencies: []
+- name: kubernetes-windows
+  version: 7ea9526bfb7d43ffdc7e171c113c6402193f2ea2aa554b7fee6bf0fc83f01532
+  fingerprint: 7ea9526bfb7d43ffdc7e171c113c6402193f2ea2aa554b7fee6bf0fc83f01532
+  sha1: sha256:56612e4f3bc142110fdbefdb14289a0489647ab1aa49c5ebd17e205ff31935b1
+  dependencies: []
+license:
+  version: e11f9acd34abf885ffdd631f86b8d72b6cde9f489348ffb70d78a1356ee3cc06
+  fingerprint: e11f9acd34abf885ffdd631f86b8d72b6cde9f489348ffb70d78a1356ee3cc06
+  sha1: sha256:9df0f596fcb64341a6b637865f0423341033c2d005b17b0acc629628a37d5ae8


### PR DESCRIPTION
This is an auto generated PR created for kubernetes upgrade to 1.18.6