### PR TITLE
Add watch disk in drain

### DIFF
--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -17,7 +17,7 @@ function main {
   if (kubelet_is_running) {
     Retry-Command $function:cordon_node cordon_node
     Retry-Command $function:drain_kubelet drain_kubelet
-    # watch_disks TODO(BM/LH): implement this?
+    watch_disks
     Retry-Command $function:delete_drained_node delete_drained_node
   }
 
@@ -36,6 +36,19 @@ function cordon_node() {
     Log-Err $_.ScriptStackTrace
     Write-Error "Exception"
   }
+}
+
+function watch_disk() {
+  ## Need to wait for disks to all be detached first
+  do {
+    Log-Out ("[{0}] Checking remaining disks" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
+    $RemainDisks = (Get-Disk | Where-Object {($_.Number -ne "0" ) -and ($_.Number -ne "1")} | Measure-Object | Select-Object Count).count
+    if ( $RemainDisks -eq 0 ){
+      return
+    }
+    Log-Out ("[{0}] disks remaining: {1}", -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
+    Start-Sleep -Milliseconds 10000
+  } while ($true)
 }
 
 function drain_kubelet() {

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -40,14 +40,14 @@ function cordon_node() {
 
 function watch_disk() {
   ## Need to wait for disks to all be detached first
+  Log-Out ("[{0}] Checking remaining disks" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
   do {
-    Log-Out ("[{0}] Checking remaining disks" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
     ## assumption is that current VM has two disks by default, device 0 and 1, others are all created by k8s
     $RemainDisks = (Get-Disk | Where-Object {($_.Number -ne "0" ) -and ($_.Number -ne "1")} | Measure-Object | Select-Object Count).count
     if ( $RemainDisks -eq 0 ){
       return
     }
-    Log-Out ("[{0}] disks remaining: {1}", -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
+    Log-Out ("[{0}] {1} disks still attached", -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
     Start-Sleep -Milliseconds 10000
   } while ($true)
 }

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -48,7 +48,7 @@ function watch_disk() {
       return
     }
     Log-Out ("[{0}] {1} disks still attached", -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
-    Start-Sleep -Milliseconds 10000
+    Start-Sleep -Milliseconds 5000
   } while ($true)
 }
 

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -40,7 +40,7 @@ function cordon_node() {
 
 function watch_disks() {
   ## Need to wait for disks to all be detached first
-  Log-Out ("[{0}] Checking remaining disks" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
+  Log-Out ("[{0}] checking for attached PVs..." -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
   do {
     ## assumption is that current VM has two disks by default, device 0 and 1, others are all created by k8s
     $RemainDisks = (Get-Disk | Where-Object {($_.Number -ne "0" ) -and ($_.Number -ne "1")} | Measure-Object | Select-Object Count).count
@@ -50,6 +50,7 @@ function watch_disks() {
     Log-Out ("[{0}] {1} disks still attached" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
     Start-Sleep -Milliseconds 5000
   } while ($true)
+  Log-Out ("[{0}] no attached PV" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
 }
 
 function drain_kubelet() {

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -42,6 +42,7 @@ function watch_disk() {
   ## Need to wait for disks to all be detached first
   do {
     Log-Out ("[{0}] Checking remaining disks" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
+    ## assumption is that current VM has two disks by default, device 0 and 1, others are all created by k8s
     $RemainDisks = (Get-Disk | Where-Object {($_.Number -ne "0" ) -and ($_.Number -ne "1")} | Measure-Object | Select-Object Count).count
     if ( $RemainDisks -eq 0 ){
       return

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -47,7 +47,7 @@ function watch_disk() {
     if ( $RemainDisks -eq 0 ){
       return
     }
-    Log-Out ("[{0}] {1} disks still attached", -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
+    Log-Out ("[{0}] {1} disks still attached" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
     Start-Sleep -Milliseconds 5000
   } while ($true)
 }

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -38,7 +38,7 @@ function cordon_node() {
   }
 }
 
-function watch_disk() {
+function watch_disks() {
   ## Need to wait for disks to all be detached first
   Log-Out ("[{0}] Checking remaining disks" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
   do {

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -45,12 +45,12 @@ function watch_disks() {
     ## assumption is that current VM has two disks by default, device 0 and 1, others are all created by k8s
     $RemainDisks = (Get-Disk | Where-Object {($_.Number -ne "0" ) -and ($_.Number -ne "1")} | Measure-Object | Select-Object Count).count
     if ( $RemainDisks -eq 0 ){
+      Log-Out ("[{0}] no attached PV" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
       return
     }
     Log-Out ("[{0}] {1} disks still attached" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
     Start-Sleep -Milliseconds 5000
   } while ($true)
-  Log-Out ("[{0}] no attached PV" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
 }
 
 function drain_kubelet() {


### PR DESCRIPTION
https://jira.eng.vmware.com/browse/PKS-3439

# Context

Currently the drain script for windows doesn't wait for disks to be detached before deleting node https://github.com/pivotal-cf/pks-kubernetes-windows-release/blob/main/jobs/kubelet-windows/templates/bin/drain.ps1.erb#L20.
This will cause issue when there are many disks attached to the node.

# Behavior

Deploy 10 pods with PV attached. 
After node is deleted, the disks are left.
```
PS C:\Users\bosh_d5d22b18a55c450>  wmic diskdrive get Name,Model,SerialNumber,Size,Status
Model                                 Name                 SerialNumber                      Size         Status
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE0   6000c29bd6a16e1dff5b31dab16bdb31  42944186880  OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE1   6000c29f2fc8a4c8816163c98609d55b  34356994560  OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE2   6000c296324325ebb15b31405a3d5a6b  1069286400   OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE5   6000c294d7ce7c6be2d0707620c7c5c6  1069286400   OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE8   6000c2932c7fec63ddf5a935a70aa8e3  1069286400   OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE11  6000c29cf0aaefd8b58cc5b27fd97071  1069286400   OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE14  6000c2961290b81659fe39eea645d79a  1069286400   OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE17  6000c29177c2b123ebc253642a1d41ef  1069286400   OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE20  6000c29246693154460c14f50e00c920  1069286400   OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE26  6000c295f0b397fb5c7ee60ee5154085  1069286400   OK
VMware Virtual disk SCSI Disk Device  \\.\PHYSICALDRIVE29  6000c295ead3ed347dcc2f51ffd14f09  1069286400   OK
```

And new pod will fail to create, because kube-controller-manager are still trying to detach the PV from deleted node and it can't find the node.

```
kubectl describe po windows-pv-1
Name:           windows-pv-1
Namespace:      default
Priority:       0
Node:           8521e6be-bb1e-4844-aa36-8e9b437d6726/10.0.0.4
Start Time:     Thu, 24 Sep 2020 02:45:12 +0000
Labels:         app=windows-pv
                controller-revision-hash=windows-pv-5bbf4cb7d
                statefulset.kubernetes.io/pod-name=windows-pv-1
Annotations:    <none>
Status:         Pending
IP:
IPs:            <none>
Controlled By:  StatefulSet/windows-pv
Containers:
  windows-pv:
    Container ID:
    Image:         stefanscherer/node-windows
    Image ID:
    Port:          <none>
    Host Port:     <none>
    Command:
      ping
      -t
      localhost
    State:          Waiting
      Reason:       ContainerCreating
    Ready:          False
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-r9ghs (ro)
      c:\var\run from www (rw)
Conditions:
  Type              Status
  Initialized       True
  Ready             False
  ContainersReady   False
  PodScheduled      True
Volumes:
  www:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  www-windows-pv-1
    ReadOnly:   false
  default-token-r9ghs:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-r9ghs
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  beta.kubernetes.io/os=windows
Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
                 windows=2019:NoSchedule
Events:
  Type     Reason              Age                  From                                           Message
  ----     ------              ----                 ----                                           -------
  Normal   Scheduled           <unknown>            default-scheduler                              Successfully assigned default/windows-pv-1 to 8521e6be-bb1e-4844-aa36-8e9b437d6726
  Warning  FailedAttachVolume  5m16s                attachdetach-controller                        Multi-Attach error for volume "pvc-506386a1-0a0d-4a59-893e-f524f748179b" Volume is already exclusively attached to one node and can't be attached to another
  Warning  FailedMount         57s (x2 over 3m13s)  kubelet, 8521e6be-bb1e-4844-aa36-8e9b437d6726  Unable to attach or mount volumes: unmounted volumes=[www], unattached volumes=[www default-token-r9ghs]: timed out waiting for the condition
```

# Solution

The drain script needs to wait for the PV detach first, then delete the node




# Dev Note
There are two default disks on the VM. We assume that other disks are created by K8s