### PR TITLE
Fix the logic of checking default attached windows' node disk

### DIFF
--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -41,9 +41,12 @@ function cordon_node() {
 function watch_disks() {
   ## Need to wait for disks to all be detached first
   Log-Out ("[{0}] checking for attached PVs..." -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
+  Log-Out ("[{0}] read non-k8s disk info from file" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
+  $Path = "/var/vcap/jobs/kubelet-windows/config/disk_info"
+  $DiskInfo = Get-Content $Path
   do {
     ## assumption is that current VM has two disks by default, device 0 and 1, others are all created by k8s
-    $RemainDisks = (Get-Disk | Where-Object {($_.Number -ne "0" ) -and ($_.Number -ne "1")} | Measure-Object | Select-Object Count).count
+    $RemainDisks = (Get-Disk | Where-Object {($_.Number -notIn $DiskInfo )} | Measure-Object | Select-Object Count).count
     if ( $RemainDisks -eq 0 ){
       Log-Out ("[{0}] no attached PV" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
       return

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -42,6 +42,7 @@ function watch_disks() {
   ## Need to wait for disks to all be detached first
   Log-Out ("[{0}] checking for attached PVs..." -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
   do {
+    Log-Out ("[{0}] Checking remaining disks" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
     ## assumption is that current VM has two disks by default, device 0 and 1, others are all created by k8s
     $RemainDisks = (Get-Disk | Where-Object {($_.Number -ne "0" ) -and ($_.Number -ne "1")} | Measure-Object | Select-Object Count).count
     if ( $RemainDisks -eq 0 ){

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -42,7 +42,6 @@ function watch_disks() {
   ## Need to wait for disks to all be detached first
   Log-Out ("[{0}] checking for attached PVs..." -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
   do {
-    Log-Out ("[{0}] Checking remaining disks" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
     ## assumption is that current VM has two disks by default, device 0 and 1, others are all created by k8s
     $RemainDisks = (Get-Disk | Where-Object {($_.Number -ne "0" ) -and ($_.Number -ne "1")} | Measure-Object | Select-Object Count).count
     if ( $RemainDisks -eq 0 ){

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -51,6 +51,7 @@ function watch_disks() {
     Log-Out ("[{0}] {1} disks still attached" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
     Start-Sleep -Milliseconds 5000
   } while ($true)
+  Log-Out ("[{0}] no attached PV" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
 }
 
 function drain_kubelet() {

--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -51,7 +51,6 @@ function watch_disks() {
     Log-Out ("[{0}] {1} disks still attached" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"), $RemainDisks)
     Start-Sleep -Milliseconds 5000
   } while ($true)
-  Log-Out ("[{0}] no attached PV" -f (get-date -Format "yyyy-MM-ddTHH:mm:ssZ"))
 }
 
 function drain_kubelet() {

--- a/jobs/kubelet-windows/templates/bin/pre-start.ps1
+++ b/jobs/kubelet-windows/templates/bin/pre-start.ps1
@@ -11,3 +11,18 @@ foreach($property in $properties) {
     $decoded = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($file_args_dict."$property"))
     $decoded | Out-File -FilePath "$base_path\config\$property"
 }
+
+## Get disk info and store inside local file
+
+$FolderPath = "/var/vcap/jobs/kubelet-windows/config/"
+$FileName = "disk_info"
+$Path = $FolderPath + $FileName
+if (!(Test-Path $Path))
+{
+    New-Item -itemType File -Path $FolderPath -Name $FileName
+    (Get-Disk | select Number).Number | Out-File -Append -Encoding ASCII $Path
+}
+else
+{
+    Write-Host "$FileName File already exists"
+}


### PR DESCRIPTION
Instead of assuming two disks attached by default, store the default disk info inside pre-start script. Then wait for other disks to detach when drain