### PR TITLE
Fix missing space

### DIFF
--- a/jobs/kubelet-windows/templates/bin/drain.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/drain.ps1.erb
@@ -83,7 +83,7 @@ function drain_kubelet() {
 
     <% if_p("kubelet-drain-delete-local-data") do |prop| %>
       <% if prop %>
-      $kubectl_args+= "--delete-local-data"
+      $kubectl_args += "--delete-local-data"
       <% end %>
     <% end %>
 


### PR DESCRIPTION
without the space before `+=`, the assign doesn't work, so the script doesn't have `--delete-local-data` command working