### PR TITLE
Fix the node taints parameter name

### DIFF
--- a/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
+++ b/jobs/kubelet-windows/templates/bin/kubelet_ctl.ps1.erb
@@ -36,14 +36,6 @@ $env:PATH+=";C:\var\vcap\packages\docker\docker\;"
   labels = labels.join(',')
 %>
 
-<%  
-  taints = ""
-  if_p('k8s-args') do |args|
-    taints = args.fetch('node-taints', "")
-    args.delete('node-taints')
-  end  
-%>
-
 <% if_p('http_proxy') do |http_proxy| %>
 $env:HTTP_PROXY=<%= http_proxy %>
 <% end %>
@@ -119,7 +111,6 @@ function start_kubelet {
     <% if !iaas.nil? -%>--cloud-provider=${cloud_provider}<% end %> `
     --hostname-override=$(get_hostname_override) `
     --node-labels=<%= labels %> `
-    --register-with-taints=<%= taints %> `
     --config="/var/vcap/jobs/kubelet-windows/config/kubeletconfig.yml" `
     --tls-cipher-suites=<%= link('kube-apiserver').p('tls-cipher-suites') %>
 


### PR DESCRIPTION
In my previous PR, I added "node-taints" into the k8s-args for kubelet, and translated it to "--register-with-taints". Actually it isn't correct. 

We only need to set the correct name "register-with-taints" into k8s-args, and then the kubelet_ctl script will  automatically insert the parameter for kubelet. So this change is just to rollback the change in my last PR. 