### PR TITLE
Bump docker to 19.03.14

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ cni/cni-plugins-windows-amd64-c74e0e996.tgz:
   size: 9678154
   object_id: da0e8048-675b-4701-68e9-7db89e88723b
   sha: 02c4d67a17a28c26cc471e56bf01dcacd104b346
-docker-windows/docker-19-03-13.zip:
-  size: 89861158
-  object_id: 28884cce-9764-45c0-7fea-e1d652dab95e
-  sha: sha256:61dee9bd38198dd2f26319c5c60206a9beee42f4346f382ab72ae68f3cca04b2
+docker-windows/docker-19-03-14.zip:
+  size: 89855637
+  object_id: 660d0971-6b02-4db1-6260-c39a4c6e97f6
+  sha: 1f2da6b6983cf8fa920b747b20f7c8f40e48392f
 flannel-v0.11.0-44-g3f87efc4-windows-amd64.tar.gz:
   size: 9548976
   object_id: 1a947dbf-c668-4e34-63c8-63d1aaa715d4


### PR DESCRIPTION
https://pks.ci.cf-app.com/teams/bosh-lifecycle-dev/pipelines/pks-api-1.10.x-bump-docker-19.03.14