### PR TITLE
Add nobridge to docker job

### DIFF
--- a/jobs/docker-windows/spec
+++ b/jobs/docker-windows/spec
@@ -8,7 +8,10 @@ templates:
 packages:
 - docker-windows
 
-properties: {}
+properties:
+  nobridge:
+    default: false
+    description: setting bridge to none if true
 
 consumes:
 - name: docker

--- a/jobs/docker-windows/templates/config/daemon.json.erb
+++ b/jobs/docker-windows/templates/config/daemon.json.erb
@@ -1,8 +1,10 @@
+# this file left intentionally blank
+# this is a placeholder for tls properties if needed in the future
+# or changing the default log location to /var/vcap/sys/log if that is ever enabled by docker
+
 {
-  <%
-  # this file left intentionally blank
-  # this is a placeholder for tls properties if needed in the future
-  # or changing the default log location to /var/vcap/sys/log if that is ever enabled by docker
-  %>
+<% if p('nobridge') %>
+  "bridge": "none"
+<% end %>
   "data-root": "c:\\var\\vcap\\data\\docker-root"
 }


### PR DESCRIPTION
This is a re-created PR for Lubron's early [commit](https://github.com/pivotal-cf/pks-kubernetes-windows-release/commit/981e246d14dc7a6722a3938ab48637fbb7983081) back in 1.9.x. Should have no effect to current product unless we set the parameter `nobridge` to true explicitly.
If `nobridge` is set to true in pks-nsx-t-release, it is meant to fix PKS-4341. 